### PR TITLE
Use DateTimeInterface in function signatures

### DIFF
--- a/src/Domain/AbstractAggregateRoot.php
+++ b/src/Domain/AbstractAggregateRoot.php
@@ -8,11 +8,11 @@ use StrictlyPHP\Domantra\Command\EventInterface;
 
 abstract class AbstractAggregateRoot
 {
-    protected \DateTimeImmutable $createdAt;
+    protected \DateTimeInterface $createdAt;
 
-    protected ?\DateTimeImmutable $updatedAt;
+    protected ?\DateTimeInterface $updatedAt;
 
-    protected ?\DateTimeImmutable $deletedAt;
+    protected ?\DateTimeInterface $deletedAt;
 
     /**
      * @var EventLogItem[]
@@ -29,7 +29,7 @@ abstract class AbstractAggregateRoot
 
     protected function recordAndApplyThat(
         EventInterface $event,
-        \DateTimeImmutable $happenedAt,
+        \DateTimeInterface $happenedAt,
     ): void {
         $classArray = explode('\\', get_class($event));
         $class = end($classArray);
@@ -65,17 +65,17 @@ abstract class AbstractAggregateRoot
         );
     }
 
-    public function getCreatedAt(): \DateTimeImmutable
+    public function getCreatedAt(): \DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): ?\DateTimeImmutable
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    public function getDeletedAt(): ?\DateTimeImmutable
+    public function getDeletedAt(): ?\DateTimeInterface
     {
         return $this->deletedAt;
     }

--- a/src/Domain/AbstractAggregateRoot.php
+++ b/src/Domain/AbstractAggregateRoot.php
@@ -8,11 +8,11 @@ use StrictlyPHP\Domantra\Command\EventInterface;
 
 abstract class AbstractAggregateRoot
 {
-    protected \DateTimeInterface $createdAt;
+    protected \DateTimeImmutable $createdAt;
 
-    protected ?\DateTimeInterface $updatedAt;
+    protected ?\DateTimeImmutable $updatedAt;
 
-    protected ?\DateTimeInterface $deletedAt;
+    protected ?\DateTimeImmutable $deletedAt;
 
     /**
      * @var EventLogItem[]
@@ -31,6 +31,7 @@ abstract class AbstractAggregateRoot
         EventInterface $event,
         \DateTimeInterface $happenedAt,
     ): void {
+        $happenedAt = \DateTimeImmutable::createFromInterface($happenedAt);
         $classArray = explode('\\', get_class($event));
         $class = end($classArray);
         $method = sprintf('applyThat%s', $class);
@@ -65,17 +66,17 @@ abstract class AbstractAggregateRoot
         );
     }
 
-    public function getCreatedAt(): \DateTimeInterface
+    public function getCreatedAt(): \DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeImmutable
     {
         return $this->updatedAt;
     }
 
-    public function getDeletedAt(): ?\DateTimeInterface
+    public function getDeletedAt(): ?\DateTimeImmutable
     {
         return $this->deletedAt;
     }

--- a/src/Domain/EventLogItem.php
+++ b/src/Domain/EventLogItem.php
@@ -11,7 +11,7 @@ readonly class EventLogItem
     public function __construct(
         public string $name,
         public EventInterface $event,
-        public \DateTimeImmutable $happenedAt,
+        public \DateTimeInterface $happenedAt,
         public \stdClass $dto,
     ) {
     }

--- a/src/Domain/EventLogItem.php
+++ b/src/Domain/EventLogItem.php
@@ -11,7 +11,7 @@ readonly class EventLogItem
     public function __construct(
         public string $name,
         public EventInterface $event,
-        public \DateTimeInterface $happenedAt,
+        public \DateTimeImmutable $happenedAt,
         public \stdClass $dto,
     ) {
     }

--- a/tests/Fixtures/Domain/UserModel.php
+++ b/tests/Fixtures/Domain/UserModel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace StrictlyPHP\Tests\Domantra\Fixtures\Domain;
 
-use DateTimeImmutable;
+use DateTimeInterface;
 
 use StrictlyPHP\Domantra\Domain\AbstractAggregateRoot;
 use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
@@ -23,7 +23,7 @@ class UserModel extends AbstractAggregateRoot
         UserId $id,
         string $username,
         string $email,
-        DateTimeImmutable $createdAt,
+        DateTimeInterface $createdAt,
     ): self {
         $model = new self();
         $model->recordAndApplyThat(
@@ -40,7 +40,7 @@ class UserModel extends AbstractAggregateRoot
         $this->email = $event->email;
     }
 
-    public function updateUsername(string $username, DateTimeImmutable $happenedAt): void
+    public function updateUsername(string $username, DateTimeInterface $happenedAt): void
     {
         $this->recordAndApplyThat(
             new UsernameWasUpdated($username),


### PR DESCRIPTION
## Summary
- Replace `DateTimeImmutable` with `DateTimeInterface` in parameters, properties, and return types across `AbstractAggregateRoot`, `EventLogItem`, and test fixtures
- Follows the Robustness Principle: accept the widest type (`DateTimeInterface`), return the narrowest (`DateTimeImmutable` kept for `ClockInterface` per PSR-20)
- Allows callers to pass both `DateTime` and `DateTimeImmutable` objects

## Test plan
- [x] `make style-fix` — no errors
- [x] `make analyze` — PHPStan level 6, no errors
- [x] `make check-coverage` — 35 tests, 101 assertions, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced timestamp parameter handling to accept a broader range of datetime types, improving compatibility while maintaining internal consistency.
  * Updated test fixtures to reflect the expanded type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->