### PR TITLE
fix: skip Redis set when TTL is zero or negative

### DIFF
--- a/src/Cache/DtoCacheHandlerPredis.php
+++ b/src/Cache/DtoCacheHandlerPredis.php
@@ -42,7 +42,9 @@ class DtoCacheHandlerPredis extends AbstractDtoCacheHandler
 
     public function set(CachedDtoInterface $dto): void
     {
-        if ($dto->getTtl() <= 0) {
+        $ttl = $dto->getTtl();
+
+        if ($ttl <= 0) {
             return;
         }
 
@@ -52,7 +54,7 @@ class DtoCacheHandlerPredis extends AbstractDtoCacheHandler
             $generatedKey,
             $data,
             'EX',
-            $dto->getTtl()
+            $ttl
         );
     }
 

--- a/src/Cache/DtoCacheHandlerPredis.php
+++ b/src/Cache/DtoCacheHandlerPredis.php
@@ -42,6 +42,10 @@ class DtoCacheHandlerPredis extends AbstractDtoCacheHandler
 
     public function set(CachedDtoInterface $dto): void
     {
+        if ($dto->getTtl() <= 0) {
+            return;
+        }
+
         $generatedKey = $this->getKey($dto->getCacheKey(), get_class($dto));
         $data = serialize($dto);
         $this->client->set(

--- a/src/Cache/DtoCacheHandlerRedis.php
+++ b/src/Cache/DtoCacheHandlerRedis.php
@@ -41,6 +41,10 @@ class DtoCacheHandlerRedis extends AbstractDtoCacheHandler
 
     public function set(CachedDtoInterface $dto): void
     {
+        if ($dto->getTtl() <= 0) {
+            return;
+        }
+
         $generatedKey = $this->getKey($dto->getCacheKey(), get_class($dto));
         $this->redis->set(
             $generatedKey,

--- a/src/Cache/DtoCacheHandlerRedis.php
+++ b/src/Cache/DtoCacheHandlerRedis.php
@@ -41,7 +41,9 @@ class DtoCacheHandlerRedis extends AbstractDtoCacheHandler
 
     public function set(CachedDtoInterface $dto): void
     {
-        if ($dto->getTtl() <= 0) {
+        $ttl = $dto->getTtl();
+
+        if ($ttl <= 0) {
             return;
         }
 
@@ -49,7 +51,7 @@ class DtoCacheHandlerRedis extends AbstractDtoCacheHandler
         $this->redis->set(
             $generatedKey,
             $dto,
-            $dto->getTtl()
+            $ttl
         );
     }
 

--- a/tests/Unit/Cache/DtoCacheHandlerPredisTest.php
+++ b/tests/Unit/Cache/DtoCacheHandlerPredisTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Domantra\Unit\Cache;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Predis\Client;
+use StrictlyPHP\Domantra\Cache\DtoCacheHandlerPredis;
+use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
+
+class DtoCacheHandlerPredisTest extends TestCase
+{
+    private Client & MockObject $client;
+    private DtoCacheHandlerPredis $handler;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['set'])
+            ->getMock();
+        $this->handler = new DtoCacheHandlerPredis($this->client);
+    }
+
+    public function testSetDoesNotCallClientWhenTtlIsZero(): void
+    {
+        $dto = $this->createMock(CachedDtoInterface::class);
+        $dto->method('getTtl')->willReturn(0);
+
+        $this->client->expects($this->never())->method('set');
+
+        $this->handler->set($dto);
+    }
+
+    public function testSetDoesNotCallClientWhenTtlIsNegative(): void
+    {
+        $dto = $this->createMock(CachedDtoInterface::class);
+        $dto->method('getTtl')->willReturn(-1);
+
+        $this->client->expects($this->never())->method('set');
+
+        $this->handler->set($dto);
+    }
+
+    public function testSetCallsClientWhenTtlIsPositive(): void
+    {
+        $dto = $this->createMock(CachedDtoInterface::class);
+        $dto->method('getTtl')->willReturn(60);
+        $dto->method('getCacheKey')->willReturn('some-key');
+
+        $this->client->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->isType('string'),
+                $this->isType('string'),
+                'EX',
+                60
+            );
+
+        $this->handler->set($dto);
+    }
+}

--- a/tests/Unit/Cache/DtoCacheHandlerPredisTest.php
+++ b/tests/Unit/Cache/DtoCacheHandlerPredisTest.php
@@ -13,6 +13,7 @@ use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
 class DtoCacheHandlerPredisTest extends TestCase
 {
     private Client & MockObject $client;
+
     private DtoCacheHandlerPredis $handler;
 
     protected function setUp(): void

--- a/tests/Unit/Cache/DtoCacheHandlerRedisTest.php
+++ b/tests/Unit/Cache/DtoCacheHandlerRedisTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Domantra\Unit\Cache;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Domantra\Cache\DtoCacheHandlerRedis;
+use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
+
+class DtoCacheHandlerRedisTest extends TestCase
+{
+    private \Redis & MockObject $redis;
+    private DtoCacheHandlerRedis $handler;
+
+    protected function setUp(): void
+    {
+        $this->redis = $this->createMock(\Redis::class);
+        $this->handler = new DtoCacheHandlerRedis($this->redis);
+    }
+
+    public function testSetDoesNotCallRedisWhenTtlIsZero(): void
+    {
+        $dto = $this->createMock(CachedDtoInterface::class);
+        $dto->method('getTtl')->willReturn(0);
+
+        $this->redis->expects($this->never())->method('set');
+
+        $this->handler->set($dto);
+    }
+
+    public function testSetDoesNotCallRedisWhenTtlIsNegative(): void
+    {
+        $dto = $this->createMock(CachedDtoInterface::class);
+        $dto->method('getTtl')->willReturn(-1);
+
+        $this->redis->expects($this->never())->method('set');
+
+        $this->handler->set($dto);
+    }
+
+    public function testSetCallsRedisWhenTtlIsPositive(): void
+    {
+        $dto = $this->createMock(CachedDtoInterface::class);
+        $dto->method('getTtl')->willReturn(60);
+        $dto->method('getCacheKey')->willReturn('some-key');
+
+        $this->redis->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->isType('string'),
+                $dto,
+                60
+            );
+
+        $this->handler->set($dto);
+    }
+}

--- a/tests/Unit/Cache/DtoCacheHandlerRedisTest.php
+++ b/tests/Unit/Cache/DtoCacheHandlerRedisTest.php
@@ -12,6 +12,7 @@ use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
 class DtoCacheHandlerRedisTest extends TestCase
 {
     private \Redis & MockObject $redis;
+
     private DtoCacheHandlerRedis $handler;
 
     protected function setUp(): void


### PR DESCRIPTION
## Summary

- Return early from `DtoCacheHandlerPredis::set()` and `DtoCacheHandlerRedis::set()` when `getTtl() <= 0`, preventing Redis from throwing `ERR invalid expire time in 'set' command`
- Add unit tests for both handlers covering TTL = 0 (no client call), TTL < 0 (no client call), and TTL > 0 (client called correctly)

## Test plan

- [ ] `DtoCacheHandlerPredisTest::testSetDoesNotCallClientWhenTtlIsZero` — passes
- [ ] `DtoCacheHandlerPredisTest::testSetDoesNotCallClientWhenTtlIsNegative` — passes
- [ ] `DtoCacheHandlerPredisTest::testSetCallsClientWhenTtlIsPositive` — passes
- [ ] `DtoCacheHandlerRedisTest::testSetDoesNotCallRedisWhenTtlIsZero` — passes
- [ ] `DtoCacheHandlerRedisTest::testSetDoesNotCallRedisWhenTtlIsNegative` — passes
- [ ] `DtoCacheHandlerRedisTest::testSetCallsRedisWhenTtlIsPositive` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cache handlers now skip writing to storage when TTL is zero or negative, avoiding unnecessary cache writes.

* **Tests**
  * Added unit tests validating cache handler behavior for zero, negative, and positive TTLs to ensure correct skip/write logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->