### PR TITLE
feat: opt-in marker interface for expansion 'not found' exceptions

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -154,3 +154,39 @@ For example, given `public TeamId $teamId`, the result will contain both `teamId
 Given `public TeamId $team`, the result will contain both `team` (the original `TeamId` object) and `teamExpanded` (the expanded DTO).
 
 The `id` property is excluded from expansion.
+
+### Exception Contract
+
+Handlers registered with `allowExpansion: true` **must** signal a missing record by throwing an exception that implements `StrictlyPHP\Domantra\Query\Exception\ItemNotFoundExceptionInterface`. Expansion catches these and substitutes `null` for the expanded value, so a dangling reference degrades gracefully instead of failing the whole response (which matters especially for paginated endpoints, where one missing row would otherwise take down the page).
+
+Any other exception bubbles out of `QueryBus::handle()` and fails the enclosing request.
+
+`ItemNotFoundException` ships implementing this interface, so existing handlers that already throw it need no change:
+
+```php
+use StrictlyPHP\Domantra\Query\Exception\ItemNotFoundException;
+
+class GetTeamByIdHandler implements SingleHandlerInterface
+{
+    public function __invoke(object $query): Team
+    {
+        $team = $this->repo->find((string) $query);
+        if ($team === null) {
+            throw new ItemNotFoundException((string) $query);
+        }
+        return $team;
+    }
+}
+```
+
+If you share a handler with an HTTP route and it throws a framework exception on a miss (for example `League\Route\Http\Exception` 404), either have that exception implement `ItemNotFoundExceptionInterface` or wrap the miss in a dedicated exception that does:
+
+```php
+use StrictlyPHP\Domantra\Query\Exception\ItemNotFoundExceptionInterface;
+
+class TeamNotFoundException extends \RuntimeException implements ItemNotFoundExceptionInterface
+{
+}
+```
+
+Handlers that throw a non-matching exception will bubble through expansion — this is intentional, so unexpected failures are surfaced rather than swallowed.

--- a/src/Query/Exception/ItemNotFoundException.php
+++ b/src/Query/Exception/ItemNotFoundException.php
@@ -6,6 +6,6 @@ namespace StrictlyPHP\Domantra\Query\Exception;
 
 use Exception;
 
-class ItemNotFoundException extends Exception
+class ItemNotFoundException extends Exception implements ItemNotFoundExceptionInterface
 {
 }

--- a/src/Query/Exception/ItemNotFoundExceptionInterface.php
+++ b/src/Query/Exception/ItemNotFoundExceptionInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Domantra\Query\Exception;
+
+use Throwable;
+
+/**
+ * Marker interface for "not found" exceptions raised by query handlers.
+ *
+ * When a handler is registered with {@see \StrictlyPHP\Domantra\Query\QueryBus::registerHandler()}
+ * with `allowExpansion: true`, DTO expansion catches any exception implementing this interface
+ * and substitutes `null` for the expanded value. Any other exception bubbles and fails the
+ * enclosing request.
+ *
+ * Consumers that share a handler with an HTTP route (and therefore throw a framework exception
+ * on a miss) can implement this interface on their own exception type without Domantra taking
+ * a dependency on any HTTP library.
+ */
+interface ItemNotFoundExceptionInterface extends Throwable
+{
+}

--- a/src/Query/QueryBus.php
+++ b/src/Query/QueryBus.php
@@ -6,6 +6,7 @@ namespace StrictlyPHP\Domantra\Query;
 
 use StrictlyPHP\Domantra\Domain\AbstractAggregateRoot;
 use StrictlyPHP\Domantra\Query\Exception\ItemNotFoundException;
+use StrictlyPHP\Domantra\Query\Exception\ItemNotFoundExceptionInterface;
 use StrictlyPHP\Domantra\Query\Handlers\DtoHandlerHandlerInterface;
 use StrictlyPHP\Domantra\Query\Handlers\PaginatedHandlerInterface;
 use StrictlyPHP\Domantra\Query\Handlers\SingleHandlerInterface;
@@ -104,7 +105,7 @@ class QueryBus implements QueryBusInterface
                         } else {
                             throw new \RuntimeException(sprintf('Handler %s must be an instance of %s or %s', $class, DtoHandlerHandlerInterface::class, SingleHandlerInterface::class));
                         }
-                    } catch (ItemNotFoundException $e) {
+                    } catch (ItemNotFoundExceptionInterface $e) {
                         $expandedValue = null;
                     }
 

--- a/tests/Unit/Domain/QueryBusTest.php
+++ b/tests/Unit/Domain/QueryBusTest.php
@@ -10,6 +10,7 @@ use StrictlyPHP\Domantra\Domain\PaginatedIdCollection;
 use StrictlyPHP\Domantra\Query\AggregateRootHandler;
 use StrictlyPHP\Domantra\Query\CachedDtoHandler;
 use StrictlyPHP\Domantra\Query\Exception\ItemNotFoundException;
+use StrictlyPHP\Domantra\Query\Exception\ItemNotFoundExceptionInterface;
 use StrictlyPHP\Domantra\Query\Handlers\DtoHandlerHandlerInterface;
 use StrictlyPHP\Domantra\Query\Handlers\PaginatedHandlerInterface;
 use StrictlyPHP\Domantra\Query\Handlers\SingleHandlerInterface;
@@ -362,5 +363,82 @@ class QueryBusTest extends TestCase
             'item' => $expandedDto,
         ];
         $this->assertEquals($expected, $response->jsonSerialize());
+    }
+
+    public function testExpandDtoSetsNullWhenConsumerExceptionImplementsMarkerInterface(): void
+    {
+        $userId = new UserId('test-id');
+        $profileId = new ProfileId('profile-id');
+
+        $userHandler = $this->createMock(SingleHandlerInterface::class);
+        $userDto = (object) [
+            'id' => $userId,
+            'name' => 'Test Name',
+            'profileId' => $profileId,
+        ];
+
+        $profileHandler = $this->createMock(DtoHandlerHandlerInterface::class);
+
+        $this->queryBus->registerHandler(UserId::class, $userHandler);
+        $this->queryBus->registerHandler(ProfileId::class, $profileHandler, true);
+
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+
+        $consumerException = new class('consumer 404') extends \RuntimeException implements ItemNotFoundExceptionInterface {
+        };
+
+        $this->cachedDtoHandler->expects($this->once())
+            ->method('handle')
+            ->with($profileId, $profileHandler)
+            ->willThrowException($consumerException);
+
+        $response = $this->queryBus->handle($userId);
+
+        $expandedDto = (object) [
+            'id' => $userId,
+            'name' => 'Test Name',
+            'profileId' => $profileId,
+            'profile' => null,
+        ];
+        $expected = (object) [
+            'item' => $expandedDto,
+        ];
+        $this->assertEquals($expected, $response->jsonSerialize());
+    }
+
+    public function testExpandDtoBubblesUnrelatedExceptions(): void
+    {
+        $userId = new UserId('test-id');
+        $profileId = new ProfileId('profile-id');
+
+        $userHandler = $this->createMock(SingleHandlerInterface::class);
+        $userDto = (object) [
+            'id' => $userId,
+            'name' => 'Test Name',
+            'profileId' => $profileId,
+        ];
+
+        $profileHandler = $this->createMock(DtoHandlerHandlerInterface::class);
+
+        $this->queryBus->registerHandler(UserId::class, $userHandler);
+        $this->queryBus->registerHandler(ProfileId::class, $profileHandler, true);
+
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+
+        $this->cachedDtoHandler->expects($this->once())
+            ->method('handle')
+            ->with($profileId, $profileHandler)
+            ->willThrowException(new \RuntimeException('boom'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $this->queryBus->handle($userId);
     }
 }


### PR DESCRIPTION
## Summary
- `QueryBus::expandDto` previously caught only the concrete `ItemNotFoundException`, so any other exception from a handler registered with `allowExpansion: true` bubbled up and failed the enclosing request. That is especially painful for paginated list endpoints, where one dangling reference takes down the entire page.
- Introduce `StrictlyPHP\Domantra\Query\Exception\ItemNotFoundExceptionInterface` as an opt-in marker, have `ItemNotFoundException` implement it, and widen the `catch` in `expandDto` to the interface. Consumers sharing handlers with HTTP routes can now implement this marker on their own exception type without Domantra taking a dependency on any HTTP library.
- Document the exception contract in `docs/queries.md` under **DTO Expansion → Exception Contract**, with consumer examples, so handler authors see the contract up front instead of discovering it at request time.

## Behaviour
- Backwards compatible: `ItemNotFoundException` still exists and is still thrown/caught as before.
- Exceptions implementing `ItemNotFoundExceptionInterface` are caught during expansion; the expanded value becomes `null`.
- Any other exception continues to bubble — surfacing unexpected failures rather than swallowing them.

## Test plan
- [x] `./vendor/bin/phpunit tests/Unit` — 40/40 passing, including two new tests: one proving a consumer exception implementing the marker is nulled, one proving an unrelated `\RuntimeException` still bubbles.
- [x] `./vendor/bin/phpstan analyse -l 6 -c phpstan.neon src tests` — clean.
- [x] `./vendor/bin/ecs` — clean.
- [ ] Redis integration suite — not run locally (requires \`docker compose up\`); CI will cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an exception interface for marking "not found" errors, enabling handlers to throw custom exceptions that are gracefully handled during data expansion.

* **Documentation**
  * Added exception contract documentation defining error signaling requirements for data expansion handlers.

* **Tests**
  * Added test coverage for exception handling during data expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->