### PR TITLE
fix: explicit nullable types on CommandBus::create() params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpunit.cache
 /vendor/
 .idea
 diff.txt

--- a/ecs.php
+++ b/ecs.php
@@ -18,7 +18,6 @@ return static function (ECSConfig $ecsConfig): void {
         SetList::SPACES,
         SetList::ARRAY,
         SetList::DOCBLOCK,
-        SetList::STRICT,
         SetList::PSR_12
     ]);
 };

--- a/src/Command/CommandBus.php
+++ b/src/Command/CommandBus.php
@@ -26,9 +26,9 @@ class CommandBus implements CommandBusInterface
     }
 
     public static function create(
-        LoggerInterface $logger = null,
-        EventBusInterface $eventBus = null,
-        DtoCacheHandlerInterface $cacheHandler = null,
+        ?LoggerInterface $logger = null,
+        ?EventBusInterface $eventBus = null,
+        ?DtoCacheHandlerInterface $cacheHandler = null,
     ): self {
         return new self(
             $logger ?? new NullLogger(),


### PR DESCRIPTION
## Summary

Two related fixes that together unblock CI on PHP 8.4 and onwards.

### 1. Explicit nullable types on `CommandBus::create()` params

PHP 8.4 deprecates implicit nullability — `Type $param = null` must be written as `?Type $param = null`. `CommandBus::create()` has three params affected:

- `LoggerInterface $logger = null`
- `EventBusInterface $eventBus = null`
- `DtoCacheHandlerInterface $cacheHandler = null`

Each consumer call (e.g. `CommandBus::create()` with defaults) emits three `Implicitly marking parameter $… as nullable is deprecated` notices on PHP 8.4+. The fix is the [PHP 8.4 migration-recommended](https://www.php.net/manual/en/migration84.deprecated.php) idiom — preserves behaviour, just adds the explicit `?` marker. Supported since PHP 7.1, so no-op on the 8.2 floor CI tests against.

### 2. Drop `SetList::STRICT` from `ecs.php`

While running CI on this PR I found a second, unrelated breakage: ECS 13.1+ hard-deprecates the `strict` set (`"dangerous to run without proper context — use Rector instead"`). Because `composer.lock` is gitignored, every fresh CI run resolves to the latest ECS minor and `make style` now hard-fails. The first build of this PR errored exactly there ([logs](https://github.com/strictlyPHP/domantra/actions/runs/26356300350/job/77583771946)).

Dropped `SetList::STRICT` from the set list. The remaining four sets (`SPACES`, `ARRAY`, `DOCBLOCK`, `PSR_12`) keep style-checking intact. Rector adoption is a follow-up if those strict rules are still wanted.

## Why this matters

Auxeris is upgrading our microservices from PHP 8.3 to 8.4. Our CI runs PHPUnit with `--display-all-issues`, so the implicit-nullable deprecations surface as build failures in every service that consumes domantra. The ECS fix is a bonus — it was breaking every domantra PR opened since the ECS 13.1 release.

## Test plan

- [x] `make style` — green against fresh ECS 13.1.3 install
- [x] `make analyze` (PHPStan level 6) — green
- [x] Local re-run of consumer test suites on PHP 8.4 with the patched library — three deprecations gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)