### PR TITLE
feat: capture pre-change dto snapshot on recorded events

### DIFF
--- a/src/Domain/AbstractAggregateRoot.php
+++ b/src/Domain/AbstractAggregateRoot.php
@@ -40,6 +40,8 @@ abstract class AbstractAggregateRoot
             throw new \RuntimeException(sprintf('Missing apply method %s in %s', $method, static::class));
         }
 
+        $previousDto = $this->snapshotDto();
+
         $this->$method($event);
 
         $useTimestampsAttributes = (new \ReflectionClass($this))->getAttributes(UseTimestamps::class);
@@ -62,8 +64,33 @@ abstract class AbstractAggregateRoot
             name: implode('.', array_map(fn (string $item) => lcfirst($item), $classArray)),
             event: $event,
             happenedAt: $happenedAt,
-            dto : json_decode(json_encode($this->getDto()))
+            dto : json_decode(json_encode($this->getDto())),
+            previousDto: $previousDto
         );
+    }
+
+    /**
+     * Snapshot of the DTO as it was before the event is applied, or null when
+     * the aggregate has no previous state (i.e. this is its first event).
+     */
+    private function snapshotDto(): ?\stdClass
+    {
+        try {
+            return json_decode(json_encode($this->getDto()));
+        } catch (\Error $e) {
+            // getDto() legitimately fails before the first event, while the
+            // aggregate's own properties are still uninitialized. If they are
+            // all initialized, the Error is a genuine bug in getDto().
+            foreach ((new \ReflectionObject($this))->getProperties() as $property) {
+                if ($property->isStatic() || $property->getDeclaringClass()->getName() === self::class) {
+                    continue;
+                }
+                if (! $property->isInitialized($this)) {
+                    return null;
+                }
+            }
+            throw $e;
+        }
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/src/Domain/EventLogItem.php
+++ b/src/Domain/EventLogItem.php
@@ -13,6 +13,7 @@ readonly class EventLogItem
         public EventInterface $event,
         public \DateTimeImmutable $happenedAt,
         public \stdClass $dto,
+        public ?\stdClass $previousDto = null,
     ) {
     }
 }

--- a/tests/Fixtures/Domain/BrokenDtoModel.php
+++ b/tests/Fixtures/Domain/BrokenDtoModel.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Domantra\Fixtures\Domain;
+
+use DateTimeInterface;
+
+use StrictlyPHP\Domantra\Domain\AbstractAggregateRoot;
+use StrictlyPHP\Domantra\Domain\UseTimestamps;
+
+#[UseTimestamps(softDelete: true)]
+class BrokenDtoModel extends AbstractAggregateRoot
+{
+    private UserId $id;
+
+    private string $username;
+
+    private string $email;
+
+    private bool $dtoBroken = false;
+
+    public static function create(
+        UserId $id,
+        string $username,
+        string $email,
+        DateTimeInterface $createdAt,
+    ): self {
+        $model = new self();
+        $model->recordAndApplyThat(
+            new UserWasCreated($id, $username, $email),
+            $createdAt
+        );
+        return $model;
+    }
+
+    protected function applyThatUserWasCreated(UserWasCreated $event): void
+    {
+        $this->id = $event->id;
+        $this->username = $event->username;
+        $this->email = $event->email;
+    }
+
+    public function updateUsername(string $username, DateTimeInterface $happenedAt): void
+    {
+        $this->recordAndApplyThat(
+            new UsernameWasUpdated($username),
+            $happenedAt
+        );
+    }
+
+    protected function applyThatUsernameWasUpdated(UsernameWasUpdated $event): void
+    {
+        $this->username = $event->username;
+    }
+
+    public function breakDto(): void
+    {
+        $this->dtoBroken = true;
+    }
+
+    public function getDto(): UserDto
+    {
+        if ($this->dtoBroken) {
+            throw new \Error('getDto is broken');
+        }
+        return new UserDto(
+            $this->id,
+            $this->username,
+            $this->email
+        );
+    }
+}

--- a/tests/Unit/Cache/DtoCacheHandlerPredisTest.php
+++ b/tests/Unit/Cache/DtoCacheHandlerPredisTest.php
@@ -12,7 +12,7 @@ use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
 
 class DtoCacheHandlerPredisTest extends TestCase
 {
-    private Client & MockObject $client;
+    private Client&MockObject $client;
 
     private DtoCacheHandlerPredis $handler;
 
@@ -28,9 +28,11 @@ class DtoCacheHandlerPredisTest extends TestCase
     public function testSetDoesNotCallClientWhenTtlIsZero(): void
     {
         $dto = $this->createMock(CachedDtoInterface::class);
-        $dto->method('getTtl')->willReturn(0);
+        $dto->method('getTtl')
+            ->willReturn(0);
 
-        $this->client->expects($this->never())->method('set');
+        $this->client->expects($this->never())
+            ->method('set');
 
         $this->handler->set($dto);
     }
@@ -38,9 +40,11 @@ class DtoCacheHandlerPredisTest extends TestCase
     public function testSetDoesNotCallClientWhenTtlIsNegative(): void
     {
         $dto = $this->createMock(CachedDtoInterface::class);
-        $dto->method('getTtl')->willReturn(-1);
+        $dto->method('getTtl')
+            ->willReturn(-1);
 
-        $this->client->expects($this->never())->method('set');
+        $this->client->expects($this->never())
+            ->method('set');
 
         $this->handler->set($dto);
     }
@@ -48,8 +52,10 @@ class DtoCacheHandlerPredisTest extends TestCase
     public function testSetCallsClientWhenTtlIsPositive(): void
     {
         $dto = $this->createMock(CachedDtoInterface::class);
-        $dto->method('getTtl')->willReturn(60);
-        $dto->method('getCacheKey')->willReturn('some-key');
+        $dto->method('getTtl')
+            ->willReturn(60);
+        $dto->method('getCacheKey')
+            ->willReturn('some-key');
 
         $this->client->expects($this->once())
             ->method('set')

--- a/tests/Unit/Cache/DtoCacheHandlerRedisTest.php
+++ b/tests/Unit/Cache/DtoCacheHandlerRedisTest.php
@@ -11,7 +11,7 @@ use StrictlyPHP\Domantra\Domain\CachedDtoInterface;
 
 class DtoCacheHandlerRedisTest extends TestCase
 {
-    private \Redis & MockObject $redis;
+    private \Redis&MockObject $redis;
 
     private DtoCacheHandlerRedis $handler;
 
@@ -24,9 +24,11 @@ class DtoCacheHandlerRedisTest extends TestCase
     public function testSetDoesNotCallRedisWhenTtlIsZero(): void
     {
         $dto = $this->createMock(CachedDtoInterface::class);
-        $dto->method('getTtl')->willReturn(0);
+        $dto->method('getTtl')
+            ->willReturn(0);
 
-        $this->redis->expects($this->never())->method('set');
+        $this->redis->expects($this->never())
+            ->method('set');
 
         $this->handler->set($dto);
     }
@@ -34,9 +36,11 @@ class DtoCacheHandlerRedisTest extends TestCase
     public function testSetDoesNotCallRedisWhenTtlIsNegative(): void
     {
         $dto = $this->createMock(CachedDtoInterface::class);
-        $dto->method('getTtl')->willReturn(-1);
+        $dto->method('getTtl')
+            ->willReturn(-1);
 
-        $this->redis->expects($this->never())->method('set');
+        $this->redis->expects($this->never())
+            ->method('set');
 
         $this->handler->set($dto);
     }
@@ -44,8 +48,10 @@ class DtoCacheHandlerRedisTest extends TestCase
     public function testSetCallsRedisWhenTtlIsPositive(): void
     {
         $dto = $this->createMock(CachedDtoInterface::class);
-        $dto->method('getTtl')->willReturn(60);
-        $dto->method('getCacheKey')->willReturn('some-key');
+        $dto->method('getTtl')
+            ->willReturn(60);
+        $dto->method('getCacheKey')
+            ->willReturn('some-key');
 
         $this->redis->expects($this->once())
             ->method('set')

--- a/tests/Unit/Command/CommandBusTest.php
+++ b/tests/Unit/Command/CommandBusTest.php
@@ -19,11 +19,11 @@ use StrictlyPHP\Domantra\Domain\EventLogItem;
 
 class CommandBusTest extends TestCase
 {
-    protected MockObject & LoggerInterface $logger;
+    protected MockObject&LoggerInterface $logger;
 
-    protected MockObject & EventBusInterface $eventBus;
+    protected MockObject&EventBusInterface $eventBus;
 
-    protected MockObject & DtoCacheHandlerInterface $cacheHandler;
+    protected MockObject&DtoCacheHandlerInterface $cacheHandler;
 
     protected CommandBus $commandBus;
 

--- a/tests/Unit/Domain/AbstractAggregateRootTest.php
+++ b/tests/Unit/Domain/AbstractAggregateRootTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StrictlyPHP\Tests\Domantra\Unit\Domain;
 
 use PHPUnit\Framework\TestCase;
+use StrictlyPHP\Tests\Domantra\Fixtures\Domain\BrokenDtoModel;
 use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserId;
 use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserModel;
 
@@ -45,6 +46,7 @@ class AbstractAggregateRootTest extends TestCase
                 'username' => 'testuser',
                 'email' => 'test@example.com',
             ],
+            'previousDto' => null,
         ], ];
         $this->assertEquals($events, json_decode(json_encode($model->_getEventLogItems()), true));
         $this->assertTrue($model->hasPendingEvents());
@@ -91,6 +93,7 @@ class AbstractAggregateRootTest extends TestCase
                     'username' => 'testuser',
                     'email' => 'test@example.com',
                 ],
+                'previousDto' => null,
             ], [
                 'name' => 'strictlyPHP.tests.domantra.fixtures.domain.usernameWasUpdated',
                 'event' => [
@@ -106,9 +109,30 @@ class AbstractAggregateRootTest extends TestCase
                     'username' => 'updateduser',
                     'email' => 'test@example.com',
                 ],
+                'previousDto' => [
+                    'id' => '78b52d55-0d03-4c6c-a3e6-4bda7d908d32',
+                    'username' => 'testuser',
+                    'email' => 'test@example.com',
+                ],
             ],
         ];
         $this->assertEquals($events, json_decode(json_encode($model->_getEventLogItems()), true));
         $this->assertTrue($model->hasPendingEvents());
+    }
+
+    public function testRecordAndApplyThatRethrowsGetDtoErrorOnInitialisedAggregate(): void
+    {
+        $model = BrokenDtoModel::create(
+            id: new UserId('78b52d55-0d03-4c6c-a3e6-4bda7d908d32'),
+            username: 'testuser',
+            email: 'test@example.com',
+            createdAt: new \DateTimeImmutable('2025-08-02 18:59:49.467350')
+        );
+        $model->breakDto();
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('getDto is broken');
+
+        $model->updateUsername('updateduser', new \DateTimeImmutable('2025-08-02 19:59:49.467350'));
     }
 }

--- a/tests/Unit/Domain/EventLogItemTest.php
+++ b/tests/Unit/Domain/EventLogItemTest.php
@@ -24,5 +24,26 @@ class EventLogItemTest extends TestCase
         $this->assertSame($event, $eventLogItem->event);
         $this->assertSame($happenedAt, $eventLogItem->happenedAt);
         $this->assertSame($dto, $eventLogItem->dto);
+        $this->assertNull($eventLogItem->previousDto);
+    }
+
+    public function testEventLogItemCreationWithPreviousDto(): void
+    {
+        $event = $this->createMock(\StrictlyPHP\Domantra\Command\EventInterface::class);
+        $happenedAt = new \DateTimeImmutable('2023-10-01 12:00:00');
+        $dto = new \stdClass();
+        $previousDto = new \stdClass();
+        $eventLogItem = new EventLogItem(
+            name: 'fooBar',
+            event: $event,
+            happenedAt: $happenedAt,
+            dto: $dto,
+            previousDto: $previousDto
+        );
+
+        $this->assertSame($event, $eventLogItem->event);
+        $this->assertSame($happenedAt, $eventLogItem->happenedAt);
+        $this->assertSame($dto, $eventLogItem->dto);
+        $this->assertSame($previousDto, $eventLogItem->previousDto);
     }
 }

--- a/tests/Unit/Domain/QueryBusTest.php
+++ b/tests/Unit/Domain/QueryBusTest.php
@@ -23,9 +23,9 @@ use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserQuery;
 
 class QueryBusTest extends TestCase
 {
-    protected AggregateRootHandler & MockObject $aggregateRootHandler;
+    protected AggregateRootHandler&MockObject $aggregateRootHandler;
 
-    protected CachedDtoHandler & MockObject $cachedDtoHandler;
+    protected CachedDtoHandler&MockObject $cachedDtoHandler;
 
     protected QueryBus $queryBus;
 
@@ -473,10 +473,15 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->exactly(2))->method('handle')->willReturnCallback(
-            fn ($id) => $id === $profileId ? $profileDto : $teamDto
-        );
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->exactly(2))
+            ->method('handle')
+            ->willReturnCallback(
+                fn ($id) => $id === $profileId ? $profileDto : $teamDto
+            );
 
         $response = $this->queryBus->handle($userId, null, null);
 
@@ -516,7 +521,10 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::OnRequest);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
         $this->cachedDtoHandler->expects($this->once())
             ->method('handle')
             ->with($profileId, $profileHandler)
@@ -524,7 +532,8 @@ class QueryBusTest extends TestCase
 
         $response = $this->queryBus->handle($userId, null, null);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($profileDto, $responseItem->profile);
         $this->assertSame($teamId, $responseItem->teamId);
         $this->assertFalse(property_exists($responseItem, 'team'), 'ExpansionPolicy::OnRequest must not auto-expand on null expand list');
@@ -550,7 +559,10 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::OnRequest);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
         $this->cachedDtoHandler->expects($this->once())
             ->method('handle')
             ->with($teamId, $teamHandler)
@@ -558,7 +570,8 @@ class QueryBusTest extends TestCase
 
         $response = $this->queryBus->handle($userId, null, ['teamId']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($teamDto, $responseItem->team);
     }
 
@@ -578,12 +591,17 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::OnRequest);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         $response = $this->queryBus->handle($userId, null, []);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($teamId, $responseItem->teamId);
         $this->assertFalse(property_exists($responseItem, 'team'), 'ExpansionPolicy::OnRequest must not expand when expand list is empty');
     }
@@ -604,12 +622,17 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::OnRequest);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         $response = $this->queryBus->handle($userId, null, ['somethingElse']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($teamId, $responseItem->teamId);
         $this->assertFalse(property_exists($responseItem, 'team'), 'ExpansionPolicy::OnRequest must not expand when source property is not named in expand list');
     }
@@ -630,8 +653,12 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         $response = $this->queryBus->handle($userId, null, []);
 
@@ -668,7 +695,10 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
         $this->cachedDtoHandler->expects($this->once())
             ->method('handle')
             ->with($profileId, $profileHandler)
@@ -676,7 +706,8 @@ class QueryBusTest extends TestCase
 
         $response = $this->queryBus->handle($userId, null, ['profileId']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($profileDto, $responseItem->profile);
         $this->assertSame($teamId, $responseItem->teamId);
         $this->assertFalse(property_exists($responseItem, 'team'), 'team should not be expanded when not in the expand list');
@@ -698,12 +729,17 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         $response = $this->queryBus->handle($userId, null, ['doesNotExist']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertFalse(property_exists($responseItem, 'profile'));
         $this->assertSame($profileId, $responseItem->profileId);
     }
@@ -724,12 +760,17 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::Disabled);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         $response = $this->queryBus->handle($userId, null, ['profileId']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertFalse(property_exists($responseItem, 'profile'), 'ExpansionPolicy::Disabled must not be overridden by expand list');
     }
 
@@ -785,7 +826,8 @@ class QueryBusTest extends TestCase
 
         $response = $this->queryBus->handle($query, null, ['profileId']);
 
-        $items = $response->jsonSerialize()->items;
+        $items = $response->jsonSerialize()
+            ->items;
         $this->assertCount(2, $items);
 
         // Each item gets its own profile DTO — guards against a regression that
@@ -820,12 +862,19 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(TeamId::class, $teamHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->once())->method('handle')->with($teamId, $teamHandler)->willReturn($teamDto);
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->once())
+            ->method('handle')
+            ->with($teamId, $teamHandler)
+            ->willReturn($teamDto);
 
         $response = $this->queryBus->handle($userId, null, ['team']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($teamDto, $responseItem->teamExpanded);
     }
 
@@ -845,13 +894,18 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         // Passing the *expanded* output key ("profile") must not expand the source field ("profileId").
         $response = $this->queryBus->handle($userId, null, ['profile']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertFalse(property_exists($responseItem, 'profile'));
         // The source field must survive a filter reject — guards against a regression
         // that wipes the original property when the expand list doesn't match.
@@ -873,12 +927,17 @@ class QueryBusTest extends TestCase
         $this->queryBus->registerHandler(UserId::class, $userHandler);
         $this->queryBus->registerHandler(ProfileId::class, $profileHandler, ExpansionPolicy::ByDefault);
 
-        $this->aggregateRootHandler->expects($this->once())->method('handle')->with($userId, $userHandler)->willReturn($userDto);
-        $this->cachedDtoHandler->expects($this->never())->method('handle');
+        $this->aggregateRootHandler->expects($this->once())
+            ->method('handle')
+            ->with($userId, $userHandler)
+            ->willReturn($userDto);
+        $this->cachedDtoHandler->expects($this->never())
+            ->method('handle');
 
         $response = $this->queryBus->handle($userId, null, ['profileId']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertNull($responseItem->profileId);
         $this->assertFalse(property_exists($responseItem, 'profile'), 'null value must not be expanded even when named in the list');
     }
@@ -907,7 +966,8 @@ class QueryBusTest extends TestCase
 
         $response = $this->queryBus->handle($userId, null, ['id']);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($userId, $responseItem->id);
         $this->assertFalse(property_exists($responseItem, 'idExpanded'));
     }
@@ -953,7 +1013,8 @@ class QueryBusTest extends TestCase
 
         $response = $this->queryBus->handle($userId);
 
-        $responseItem = $response->jsonSerialize()->item;
+        $responseItem = $response->jsonSerialize()
+            ->item;
         $this->assertSame($profileId, $responseItem->profile, 'raw `profile` field must not be overwritten by expansion of `profileId`');
         $this->assertSame($profileDto, $responseItem->profileExpanded);
     }

--- a/tests/Unit/Query/AggregateRootHandlerTest.php
+++ b/tests/Unit/Query/AggregateRootHandlerTest.php
@@ -18,7 +18,7 @@ use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserModel;
 
 class AggregateRootHandlerTest extends TestCase
 {
-    private DtoCacheHandlerInterface & MockObject $cacheHandler;
+    private DtoCacheHandlerInterface&MockObject $cacheHandler;
 
     protected AggregateRootHandler $handler;
 

--- a/tests/Unit/Query/CachedDtoHandlerTest.php
+++ b/tests/Unit/Query/CachedDtoHandlerTest.php
@@ -14,7 +14,7 @@ use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserId;
 
 class CachedDtoHandlerTest extends TestCase
 {
-    private DtoCacheHandlerInterface & MockObject $cacheHandler;
+    private DtoCacheHandlerInterface&MockObject $cacheHandler;
 
     protected CachedDtoHandler $handler;
 
@@ -27,7 +27,8 @@ class CachedDtoHandlerTest extends TestCase
     public function testHandleReturnsCachedDto(): void
     {
         $query = $this->createMock(\Stringable::class);
-        $query->method('__toString')->willReturn('test-id');
+        $query->method('__toString')
+            ->willReturn('test-id');
 
         $dto = new UserDto(
             new UserId('test-id'),
@@ -66,7 +67,8 @@ class CachedDtoHandlerTest extends TestCase
     public function testHandleLoadsAndCachesWhenNotInCache(): void
     {
         $query = $this->createMock(\Stringable::class);
-        $query->method('__toString')->willReturn('test-id');
+        $query->method('__toString')
+            ->willReturn('test-id');
 
         $dto = new UserDto(
             new UserId('test-id'),


### PR DESCRIPTION
## Summary
- `EventLogItem` gains a nullable `previousDto` property (defaulted, so existing constructor calls are unaffected) carrying the aggregate's DTO state as it was **before** the event was applied.
- `AbstractAggregateRoot::recordAndApplyThat()` snapshots the DTO ahead of calling the `applyThat...()` method and passes it through, so every event dispatched by `CommandBus` now includes both `dto` (post-change) and `previousDto` (pre-change).
- On an aggregate's first event there is no previous state, so `previousDto` is `null`. Because `getDto()` legitimately throws an `Error` on uninitialised properties at that point, the snapshot guards it — but only treats the `Error` as "first event" if the aggregate genuinely has uninitialised properties (checked via reflection, excluding the base class's optional timestamp properties). A real bug in `getDto()` on an initialised aggregate is rethrown, not masked.
- Multi-event commands chain naturally: event N's `previousDto` equals event N-1's `dto`, so consumers can diff each transition.

## Tests
- `AbstractAggregateRootTest`: creation event asserts `previousDto: null`; update event asserts the pre-update snapshot; new test proves a genuine `getDto()` `Error` on an initialised aggregate surfaces (new `BrokenDtoModel` fixture).
- `EventLogItemTest`: `previousDto` defaults to `null` and passes through when provided.
- Full unit suite green (57 tests), phpstan level 6 clean, ecs clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event records now include the aggregate’s previous state when available, improving visibility into changes over time.
  * Previous state information is optional and remains unavailable for initial events.

* **Bug Fixes**
  * DTO generation errors on initialized aggregates are now surfaced instead of being silently ignored.

* **Tests**
  * Added coverage for previous-state recording, default behavior, and DTO error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->