### PR TITLE
fix: allow recording events on aggregates without UseTimestamps

### DIFF
--- a/src/Domain/AbstractAggregateRoot.php
+++ b/src/Domain/AbstractAggregateRoot.php
@@ -45,8 +45,8 @@ abstract class AbstractAggregateRoot
         $this->$method($event);
 
         $useTimestampsAttributes = (new \ReflectionClass($this))->getAttributes(UseTimestamps::class);
-        $useTimestamps = (bool) $useTimestampsAttributes;
-        $softDelete = $useTimestampsAttributes[0]->newInstance()->softDelete ?? false;
+        $useTimestamps = $useTimestampsAttributes !== [];
+        $softDelete = $useTimestamps && $useTimestampsAttributes[0]->newInstance()->softDelete;
 
         if ($useTimestamps) {
             if (! isset($this->createdAt)) {

--- a/tests/Fixtures/Domain/TimestamplessModel.php
+++ b/tests/Fixtures/Domain/TimestamplessModel.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StrictlyPHP\Tests\Domantra\Fixtures\Domain;
+
+use DateTimeInterface;
+
+use StrictlyPHP\Domantra\Domain\AbstractAggregateRoot;
+
+class TimestamplessModel extends AbstractAggregateRoot
+{
+    private UserId $id;
+
+    private string $username;
+
+    private string $email;
+
+    public static function create(
+        UserId $id,
+        string $username,
+        string $email,
+        DateTimeInterface $createdAt,
+    ): self {
+        $model = new self();
+        $model->recordAndApplyThat(
+            new UserWasCreated($id, $username, $email),
+            $createdAt
+        );
+        return $model;
+    }
+
+    protected function applyThatUserWasCreated(UserWasCreated $event): void
+    {
+        $this->id = $event->id;
+        $this->username = $event->username;
+        $this->email = $event->email;
+    }
+
+    public function updateUsername(string $username, DateTimeInterface $happenedAt): void
+    {
+        $this->recordAndApplyThat(
+            new UsernameWasUpdated($username),
+            $happenedAt
+        );
+    }
+
+    protected function applyThatUsernameWasUpdated(UsernameWasUpdated $event): void
+    {
+        $this->username = $event->username;
+    }
+
+    public function getDto(): UserDto
+    {
+        return new UserDto(
+            $this->id,
+            $this->username,
+            $this->email
+        );
+    }
+}

--- a/tests/Unit/Domain/AbstractAggregateRootTest.php
+++ b/tests/Unit/Domain/AbstractAggregateRootTest.php
@@ -6,6 +6,7 @@ namespace StrictlyPHP\Tests\Domantra\Unit\Domain;
 
 use PHPUnit\Framework\TestCase;
 use StrictlyPHP\Tests\Domantra\Fixtures\Domain\BrokenDtoModel;
+use StrictlyPHP\Tests\Domantra\Fixtures\Domain\TimestamplessModel;
 use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserId;
 use StrictlyPHP\Tests\Domantra\Fixtures\Domain\UserModel;
 
@@ -134,5 +135,24 @@ class AbstractAggregateRootTest extends TestCase
         $this->expectExceptionMessage('getDto is broken');
 
         $model->updateUsername('updateduser', new \DateTimeImmutable('2025-08-02 19:59:49.467350'));
+    }
+
+    public function testRecordAndApplyThatWorksWithoutUseTimestampsAttribute(): void
+    {
+        $now = new \DateTimeImmutable('2025-08-02 18:59:49.467350');
+        $model = TimestamplessModel::create(
+            id: new UserId('78b52d55-0d03-4c6c-a3e6-4bda7d908d32'),
+            username: 'testuser',
+            email: 'test@example.com',
+            createdAt: $now
+        );
+        $model->updateUsername('updateduser', $now->modify('+1 hour'));
+
+        $items = $model->_getEventLogItems();
+        $this->assertCount(2, $items);
+        $this->assertNull($items[0]->previousDto);
+        $this->assertSame('testuser', $items[0]->dto->username);
+        $this->assertSame('testuser', $items[1]->previousDto->username);
+        $this->assertSame('updateduser', $items[1]->dto->username);
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #43 (stacked on that branch; will retarget to `main` when it merges).

`AbstractAggregateRoot::recordAndApplyThat()` crashed with "Call to a member function newInstance() on null" for any aggregate **without** the `#[UseTimestamps]` attribute:

```php
$softDelete = $useTimestampsAttributes[0]->newInstance()->softDelete ?? false;
```

`??` only suppresses the undefined-index notice — it does not protect the method call on the resulting `null`, so the first recorded event fataled. Every existing fixture carried the attribute, which is why this stayed latent.

Fixed by testing for the attribute before instantiating it (`softDelete` is a typed bool with a default, so the `?? false` was dead weight either way):

```php
$useTimestamps = $useTimestampsAttributes !== [];
$softDelete = $useTimestamps && $useTimestampsAttributes[0]->newInstance()->softDelete;
```

## Tests
- New `TimestamplessModel` fixture (no `#[UseTimestamps]`) with a create + update test asserting events record cleanly and the `previousDto` chain from #43 holds. Fails with the fatal before the fix.
- Full unit suite green (58 tests), phpstan level 6 clean, ecs clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event logging now works correctly for models that do not use timestamp tracking.
  * Existing timestamp and soft-delete behavior remains supported.

* **Tests**
  * Added coverage for creating and updating models without timestamp attributes.
  * Verified event history and current/previous user data are recorded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->