### PR TITLE
chore: remove obsolete PKSA-5jz8-6tcw-pbk4 audit ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,5 @@
     "php-coveralls/php-coveralls": "^2.7"
   },
   "minimum-stability": "stable",
-  "prefer-stable": true,
-  "config": {
-    "audit": {
-      "ignore": {
-        "PKSA-5jz8-6tcw-pbk4": "PHPUnit argument-injection advisory covers <=12.5.21 (incl. 11.x). Fix requires PHP 8.3+ (phpunit ^12.5.22) or 8.4+ (^13.1.6); staying on 11.x to preserve PHP 8.2 baseline."
-      }
-    }
-  }
+  "prefer-stable": true
 }


### PR DESCRIPTION
## Summary

Removes the `config.audit.ignore` entry for `PKSA-5jz8-6tcw-pbk4` from `composer.json`. The advisory has been re-scoped upstream to `>=12.5.21,<12.5.22` and `>=13.1.5,<13.1.6`, so it no longer covers the PHPUnit 11.x line this project uses — the ignore is dead config that suppresses nothing.

## Verification

Ran in the project Docker image against a fresh resolve (phpunit 11.5.56):

```
$ composer validate --no-check-publish   # OK
$ composer audit
No security vulnerability advisories found.  # exit 0
```

Also re-checked the Packagist security-advisories API on 2026-08-11 — neither `PKSA-5jz8-6tcw-pbk4` nor `PKSA-z3gr-8qht-p93v` (fixed in 11.5.50) applies to the resolved version.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an exception that ignored a known PHPUnit security advisory during dependency audits.
  * Dependency auditing will now report this advisory normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->